### PR TITLE
Shifting to a pure plugins_url() call to make folder renaming irrelevant

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,5 @@ Adds a select2 facet type for [FacetWP](https://facetwp.com/)
 
 ## Installation
 * Click the "Download ZIP" button on the right side of this GitHub page.
-* Rename the unzipped folder to "facetwp-select2"
 * Upload the folder into the /wp-content/plugins/ directory
 * Activate the plugin (FacetWP must also be active)

--- a/facetwp-select2.php
+++ b/facetwp-select2.php
@@ -41,15 +41,13 @@ class FWP_Select2
             return;
         }
 
-        $plugins_url = plugins_url( 'facetwp-select2' );
-
         // ACF5 ships with an older version
         wp_deregister_script( 'select2' );
         wp_deregister_style( 'select2' );
 
         // Register
-        wp_register_script( 'select2', $plugins_url . '/select2/select2.min.js', array( 'jquery' ), '4.0.0' );
-        wp_register_style( 'select2', $plugins_url . '/select2/select2.min.css', array(), '4.0.0' );
+        wp_register_script( 'select2', plugins_url( 'select2/select2.min.js', __FILE__ ), array( 'jquery' ), '4.0.0' );
+        wp_register_style( 'select2', plugins_url( 'select2/select2.min.css', __FILE__), array(), '4.0.0' );
 
         // Enqueue
         wp_enqueue_script( 'select2' );


### PR DESCRIPTION
Reducing installation complexity is good!

This file package looks like a WordPress plugin. It smells like one too - from file structure to WP-compatible plugin info and system hooks... but it doesn't install cleanly! After downloading the zip you have to remove the branch from the folder name, otherwise the CSS and JS scripts will enqueue and 404. 

Not a big deal, but it might be misleading for somebody that goes a familiar route and uploads the entire zip to their site through the plugin upload interface. Like me ;)

This PR changes the `wp_register_x()` hooks to pull directly from the `plugins_url()` based on the `__FILE__` instead of assuming that we're at `/wp-content/plugins/facetwp-select2/` !